### PR TITLE
Ignore linting rule ember/no-side-effects

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable ember/no-side-effects */
 import EmberObject, { computed, defineProperty, get, set } from '@ember/object';
 
 export default (options = {}) => {


### PR DESCRIPTION
This PR disables a linting rule - the whole addon is about that side-effect, now.